### PR TITLE
Add `photobooth:ignore` bounding filter tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+- Adds support for the `photobooth:ignore` tag which can be used in auto-capture orbital and point-cloud mode to ignore instances and their descendants in bound calculations.
+- Changed the bindings module tag to `photobooth:bindings`. The old tag is still supported and will connect.
+
 ### [2.8.0] - 2026/08/08
 - Add scroll wheel support for controlling the distance scale during orbital and point cloud auto capture modes
 - Fix UI captures by reverting to starter gui capture again - roblox enabled the `FFlagRenderCapturePlayerGuiMode2`

--- a/src/Main/Bindings/Interface/default.project.json
+++ b/src/Main/Bindings/Interface/default.project.json
@@ -9,7 +9,7 @@
 	"tree": {
 		"$path": "src",
 		"$properties": {
-			"Tags": [ "Photobooth_Bindings" ]
+			"Tags": [ "photobooth:bindings" ]
 		},
 
 		"Wally": {

--- a/src/Main/Bindings/init.luau
+++ b/src/Main/Bindings/init.luau
@@ -127,7 +127,7 @@ function Bindings.setup(plugin: Plugin)
 	connectBinding.Archivable = false
 	connectBinding.Name = "ConnectBinding"
 	connectBinding.OnInvoke = function(instance: Instance)
-		if instance:HasTag("Photobooth_Bindings") then
+		if instance:HasTag("photobooth:bindings") or instance:HasTag("Photobooth_Bindings") then
 			connectBindings(plugin, instance)
 		end
 	end

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
@@ -74,7 +74,7 @@ function AABBHelper.getPVBoundingBox(pvInstance: PVInstance, filter: ((PVInstanc
 		while #stack > 0 do
 			local popped = table.remove(stack)
 			if popped and popped:IsA("PVInstance") then
-				local filterResult = if filter then filter(popped) else true
+				local filterResult = filter(popped)
 				if filterResult == true and popped:IsA("BasePart") then
 					table.insert(parts, popped)
 				elseif filterResult == nil then

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
@@ -1,5 +1,7 @@
 local AABBHelper = {}
 
+AABBHelper.IGNORE_TAG = "photobooth:ignore"
+
 -- Private
 
 local function getPartBounds(part: BasePart)
@@ -67,23 +69,21 @@ The predicate of this function can return `true`, `false`, or `nil` with differe
 	* `false`: The Instance does not match the criteria of the search, but will continue to look through its descendants.
 	* `nil`: The Instance does not match the criteria of the search and will **not** continue to look through its descendants.
 --]]
-function AABBHelper.getFilteredParts(instance: Instance, filter: ((PVInstance) -> boolean?)?)
+function AABBHelper.getFilteredParts(instance: Instance, filter: ((Instance) -> boolean?)?)
 	local parts = {}
 	if filter then
 		local stack: { Instance } = { instance }
 		while #stack > 0 do
-			local popped = table.remove(stack)
-			if popped and popped:IsA("PVInstance") then
-				local filterResult = filter(popped)
-				if filterResult == true and popped:IsA("BasePart") then
-					table.insert(parts, popped)
-				elseif filterResult == nil then
-					continue
-				end
+			local popped = table.remove(stack) :: Instance
+			local filterResult = filter(popped)
+			if filterResult == nil then
+				continue
+			elseif filterResult == true and popped:IsA("BasePart") then
+				table.insert(parts, popped)
+			end
 
-				for _, child in popped:GetChildren() do
-					table.insert(stack, child)
-				end
+			for _, child in popped:GetChildren() do
+				table.insert(stack, child)
 			end
 		end
 	else
@@ -96,13 +96,8 @@ function AABBHelper.getFilteredParts(instance: Instance, filter: ((PVInstance) -
 	return parts
 end
 
-function AABBHelper.getFilteredPVBoundingBox(pvInstance: PVInstance)
-	local filteredParts = AABBHelper.getFilteredParts(pvInstance, function(candidate)
-		return if candidate:HasTag("photobooth:ignore") then nil else true
-	end)
-
-	local bboxCF, bboxSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), filteredParts)
-	return bboxCF, bboxSize
+function AABBHelper.ignoreTagFilter(candidate: Instance): boolean?
+	return if candidate:HasTag(AABBHelper.IGNORE_TAG) then nil else true
 end
 
 --

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
@@ -67,10 +67,10 @@ The predicate of this function can return `true`, `false`, or `nil` with differe
 	* `false`: The Instance does not match the criteria of the search, but will continue to look through its descendants.
 	* `nil`: The Instance does not match the criteria of the search and will **not** continue to look through its descendants.
 --]]
-function AABBHelper.getPVBoundingBox(pvInstance: PVInstance, filter: ((PVInstance) -> boolean?)?)
+function AABBHelper.getFilteredParts(instance: Instance, filter: ((PVInstance) -> boolean?)?)
 	local parts = {}
 	if filter then
-		local stack: { Instance } = { pvInstance }
+		local stack: { Instance } = { instance }
 		while #stack > 0 do
 			local popped = table.remove(stack)
 			if popped and popped:IsA("PVInstance") then
@@ -87,14 +87,13 @@ function AABBHelper.getPVBoundingBox(pvInstance: PVInstance, filter: ((PVInstanc
 			end
 		end
 	else
-		parts = pvInstance:QueryDescendants("BasePart")
-		if pvInstance:IsA("BasePart") then
-			table.insert(parts, pvInstance)
+		parts = instance:QueryDescendants("BasePart")
+		if instance:IsA("BasePart") then
+			table.insert(parts, instance)
 		end
 	end
 
-	local boundCF, boundSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), parts)
-	return boundCF, boundSize
+	return parts
 end
 
 --

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
@@ -1,0 +1,102 @@
+local AABBHelper = {}
+
+-- Private
+
+local function getPartBounds(part: BasePart)
+	if part:IsA("MeshPart") then
+		-- bug on Roblox's end means we need this hacky solution to read a mesh part's accurate CFrame / Size
+		-- https://devforum.roblox.com/t/avatar-body-parts-dont-match-the-size-listed-in-the-explorer/3101124
+		local meshPart = Instance.new("MeshPart")
+		meshPart:ApplyMesh(part)
+		meshPart.CFrame = part.CFrame
+		meshPart.Size = part.Size
+
+		local model = Instance.new("Model")
+		meshPart.Parent = model
+		local partCF, partSize = model:GetBoundingBox()
+		model:Destroy()
+
+		return partCF, partSize
+	end
+	return part.CFrame, part.Size
+end
+
+-- Public
+
+function AABBHelper.getMinMax(orientation: CFrame, parts: { BasePart }): (Vector3, Vector3)
+	local corners = {}
+	local rotation = orientation.Rotation
+	for _, part in parts do
+		local partCorners = {}
+		local partCF, partSize = getPartBounds(part)
+		local partSize2 = partSize / 2
+
+		for i = 0, 7 do
+			-- stylua: ignore
+			partCorners[i + 1] = partCF * (partSize2 * Vector3.new(
+				2 * (math.floor(i / 4) % 2) - 1,
+				2 * (math.floor(i / 2) % 2) - 1,
+				2 * (i % 2) - 1
+			))
+		end
+
+		for _, corner in partCorners do
+			table.insert(corners, rotation:PointToObjectSpace(corner))
+		end
+	end
+
+	local max = corners[1]
+	local min = corners[1]
+	for i = 2, #corners do
+		max = max:Max(corners[i])
+		min = min:Min(corners[i])
+	end
+
+	return min, max
+end
+
+function AABBHelper.getBoundingBox(orientation: CFrame, parts: { BasePart }): (CFrame, Vector3)
+	local rotation = orientation.Rotation
+	local min, max = AABBHelper.getMinMax(rotation, parts)
+	return rotation * CFrame.new((min + max) / 2), max - min
+end
+
+--[[
+The predicate of this function can return `true`, `false`, or `nil` with different behaviors for each:
+	* `true`: The Instance successfully matches the criteria of the search.
+	* `false`: The Instance does not match the criteria of the search, but will continue to look through its descendants.
+	* `nil`: The Instance does not match the criteria of the search and will **not** continue to look through its descendants.
+--]]
+function AABBHelper.getPVBoundingBox(pvInstance: PVInstance, filter: ((PVInstance) -> boolean?)?)
+	local parts = {}
+	if filter then
+		local stack: { Instance } = { pvInstance }
+		while #stack > 0 do
+			local popped = table.remove(stack)
+			if popped and popped:IsA("PVInstance") then
+				local filterResult = if filter then filter(popped) else true
+				if filterResult == true and popped:IsA("BasePart") then
+					table.insert(parts, popped)
+				elseif filterResult == nil then
+					continue
+				end
+
+				for _, child in popped:GetChildren() do
+					table.insert(stack, child)
+				end
+			end
+		end
+	else
+		parts = pvInstance:QueryDescendants("BasePart")
+		if pvInstance:IsA("BasePart") then
+			table.insert(parts, pvInstance)
+		end
+	end
+
+	local boundCF, boundSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), parts)
+	return boundCF, boundSize
+end
+
+--
+
+return AABBHelper

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
@@ -47,11 +47,15 @@ function AABBHelper.getMinMax(orientation: CFrame, parts: { BasePart }): (Vector
 		end
 	end
 
-	local max = corners[1]
-	local min = corners[1]
-	for i = 2, #corners do
-		max = max:Max(corners[i])
-		min = min:Min(corners[i])
+	local max = Vector3.zero
+	local min = Vector3.zero
+	if #corners > 0 then
+		max = corners[1]
+		min = corners[1]
+		for i = 2, #corners do
+			max = max:Max(corners[i])
+			min = min:Min(corners[i])
+		end
 	end
 
 	return min, max

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
@@ -96,6 +96,12 @@ function AABBHelper.getFilteredParts(instance: Instance, filter: ((PVInstance) -
 	return parts
 end
 
+AABBHelper.filters = {
+	ignoreTag = function(pvInstance)
+		return if pvInstance:HasTag("photobooth:ignore") then nil else true
+	end,
+} :: { [string]: (PVInstance) -> boolean? }
+
 --
 
 return AABBHelper

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/AABBHelper.luau
@@ -96,11 +96,14 @@ function AABBHelper.getFilteredParts(instance: Instance, filter: ((PVInstance) -
 	return parts
 end
 
-AABBHelper.filters = {
-	ignoreTag = function(pvInstance)
-		return if pvInstance:HasTag("photobooth:ignore") then nil else true
-	end,
-} :: { [string]: (PVInstance) -> boolean? }
+function AABBHelper.getFilteredPVBoundingBox(pvInstance: PVInstance)
+	local filteredParts = AABBHelper.getFilteredParts(pvInstance, function(candidate)
+		return if candidate:HasTag("photobooth:ignore") then nil else true
+	end)
+
+	local bboxCF, bboxSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), filteredParts)
+	return bboxCF, bboxSize
+end
 
 --
 

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/PointCloud.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/PointCloud.luau
@@ -1,4 +1,5 @@
 local AssetService = game:GetService("AssetService")
+local CollectionService = game:GetService("CollectionService")
 
 local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local Future = require(pluginRoot.Packages.Future)
@@ -177,18 +178,38 @@ function PointCloudClass._watchPart(self: PointCloud, part: BasePart): Watcher
 	}
 end
 
+function PointCloudClass._refreshWatchers(self: PointCloud)
+	local wanted: { [BasePart]: true } = {}
+	for _, part in AABBHelper.getFilteredParts(self.subject, AABBHelper.ignoreTagFilter) do
+		wanted[part] = true
+	end
+
+	local changed = false
+
+	for part, watcher in self.watchers do
+		if not wanted[part] then
+			watcher.cleanup()
+			self.watchers[part] = nil
+			changed = true
+		end
+	end
+
+	for part, _ in wanted do
+		if not self.watchers[part] then
+			self.watchers[part] = self:_watchPart(part)
+			changed = true
+		end
+	end
+
+	return changed
+end
+
 function PointCloudClass._initWatchers(self: PointCloud)
-	if self.subject:IsA("BasePart") then
-		self.watchers[self.subject] = self:_watchPart(self.subject)
-	end
+	self:_refreshWatchers()
 
-	for _, part in self.subject:QueryDescendants("BasePart") do
-		self.watchers[part] = self:_watchPart(part)
-	end
-
-	self.trove:Add(self.subject.DescendantAdded:Connect(function(descendant)
-		if descendant:IsA("BasePart") then
-			self.watchers[descendant] = self:_watchPart(descendant)
+	self.trove:Add(self.subject.DescendantAdded:Connect(function(_descendant)
+		local isChanged = self:_refreshWatchers()
+		if isChanged then
 			self:recalculateVertices()
 		end
 	end))
@@ -200,6 +221,18 @@ function PointCloudClass._initWatchers(self: PointCloud)
 			self:recalculateVertices()
 		end
 	end))
+
+	local function onIgnoreTagChanged(instance: Instance)
+		if instance == self.subject or instance:IsDescendantOf(self.subject) then
+			local isChanged = self:_refreshWatchers()
+			if isChanged then
+				self:recalculateVertices()
+			end
+		end
+	end
+
+	self.trove:Add(CollectionService:GetInstanceAddedSignal(AABBHelper.IGNORE_TAG):Connect(onIgnoreTagChanged))
+	self.trove:Add(CollectionService:GetInstanceRemovedSignal(AABBHelper.IGNORE_TAG):Connect(onIgnoreTagChanged))
 
 	self.trove:Add(function()
 		for part, _ in self.watchers do

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/PointCloud.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/PointCloud.luau
@@ -4,6 +4,8 @@ local pluginRoot = script:FindFirstAncestor("PluginRoot")
 local Future = require(pluginRoot.Packages.Future)
 local Trove = require(pluginRoot.Packages.Trove)
 
+local AABBHelper = require(script.Parent.AABBHelper)
+
 local BLOCK = { 0, 1, 2, 3, 4, 5, 6, 7 }
 local WEDGE = { 0, 1, 3, 4, 5, 7 }
 local CORNER_WEDGE = { 0, 1, 4, 5, 6 }
@@ -57,32 +59,6 @@ function PointCloudStatic.new(subject: Instance, tryUseMeshVertices: boolean?, m
 	return self
 end
 
-function PointCloudStatic.getPVBoundingBox(pvInstance: PVInstance)
-	local bboxCF, bboxSize = CFrame.identity, Vector3.one
-	if pvInstance:IsA("Model") then
-		bboxCF, bboxSize = pvInstance:GetBoundingBox()
-	elseif pvInstance:IsA("BasePart") then
-		if not pvInstance:IsA("MeshPart") then
-			bboxCF, bboxSize = pvInstance.CFrame, pvInstance.Size
-		else
-			-- bug on Roblox's end means we need this hacky solution to read a mesh part's accurate CFrame / Size
-			-- https://devforum.roblox.com/t/avatar-body-parts-dont-match-the-size-listed-in-the-explorer/3101124
-			local meshPart = Instance.new("MeshPart")
-			meshPart:ApplyMesh(pvInstance)
-			meshPart.CFrame = pvInstance.CFrame
-			meshPart.Size = pvInstance.Size
-
-			local model = Instance.new("Model")
-			meshPart.Parent = model
-			local partCF, partSize = model:GetBoundingBox()
-			model:Destroy()
-
-			bboxCF, bboxSize = partCF, partSize
-		end
-	end
-	return bboxCF, bboxSize
-end
-
 -- Private
 
 local function getPointCloud(cf: CFrame, size2: Vector3, indices: { number })
@@ -106,7 +82,7 @@ local function getPartPointCloud(part: BasePart)
 		indices = CORNER_WEDGE
 	end
 
-	local partCF, partSize = PointCloudStatic.getPVBoundingBox(part)
+	local partCF, partSize = AABBHelper.getPVBoundingBox(part)
 	return getPointCloud(partCF, partSize / 2, indices)
 end
 

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/PointCloud.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/PointCloud.luau
@@ -82,7 +82,7 @@ local function getPartPointCloud(part: BasePart)
 		indices = CORNER_WEDGE
 	end
 
-	local partCF, partSize = AABBHelper.getPVBoundingBox(part)
+	local partCF, partSize = part.CFrame, part.Size
 	return getPointCloud(partCF, partSize / 2, indices)
 end
 

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -343,8 +343,7 @@ function AutoCaptureControllerClass._hookOrbital(self: AutoCaptureController)
 		local scaledFov2 = math.atan(math.tan(math.rad(camera.FieldOfView / 2)) * scaleY)
 		local sinFov2 = math.sin(scaledFov2 * math.min(1, aspect))
 
-		local filteredParts = AABBHelper.getFilteredParts(pvInstance, AABBHelper.filters.ignoreTag)
-		local _bboxCF, bboxSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), filteredParts)
+		local _bboxCF, bboxSize = AABBHelper.getFilteredPVBoundingBox(pvInstance)
 		local radius = bboxSize.Magnitude / 2
 
 		local distance = (radius / sinFov2) * dynamic.distanceScale

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -343,7 +343,7 @@ function AutoCaptureControllerClass._hookOrbital(self: AutoCaptureController)
 		local scaledFov2 = math.atan(math.tan(math.rad(camera.FieldOfView / 2)) * scaleY)
 		local sinFov2 = math.sin(scaledFov2 * math.min(1, aspect))
 
-		local filteredParts = AABBHelper.getFilteredParts(pvInstance)
+		local filteredParts = AABBHelper.getFilteredParts(pvInstance, AABBHelper.filters.ignoreTag)
 		local _bboxCF, bboxSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), filteredParts)
 		local radius = bboxSize.Magnitude / 2
 

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -14,6 +14,7 @@ local appRoot = script:FindFirstAncestor("AutoCapture")
 local RenderPriorities = require(appRoot.RenderPriorities)
 
 local AnimationManager = require(script.AnimationManager)
+local AABBHelper = require(script.AABBHelper)
 local PointCloud = require(script.PointCloud)
 
 local CAMERA_TYPE = Enum.CameraType.Scriptable
@@ -153,8 +154,6 @@ function AutoCaptureControllerStatic.new()
 
 	return self
 end
-
-AutoCaptureControllerStatic.getPVBoundingBox = PointCloud.getPVBoundingBox
 
 -- Private
 
@@ -344,7 +343,7 @@ function AutoCaptureControllerClass._hookOrbital(self: AutoCaptureController)
 		local scaledFov2 = math.atan(math.tan(math.rad(camera.FieldOfView / 2)) * scaleY)
 		local sinFov2 = math.sin(scaledFov2 * math.min(1, aspect))
 
-		local _bboxCenter, bboxSize = PointCloud.getPVBoundingBox(pvInstance)
+		local _bboxCenter, bboxSize = AABBHelper.getPVBoundingBox(pvInstance)
 		local radius = bboxSize.Magnitude / 2
 
 		local distance = (radius / sinFov2) * dynamic.distanceScale

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -343,7 +343,8 @@ function AutoCaptureControllerClass._hookOrbital(self: AutoCaptureController)
 		local scaledFov2 = math.atan(math.tan(math.rad(camera.FieldOfView / 2)) * scaleY)
 		local sinFov2 = math.sin(scaledFov2 * math.min(1, aspect))
 
-		local _bboxCF, bboxSize = AABBHelper.getFilteredPVBoundingBox(pvInstance)
+		local filteredParts = AABBHelper.getFilteredParts(pvInstance, AABBHelper.ignoreTagFilter)
+		local _bboxCF, bboxSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), filteredParts)
 		local radius = bboxSize.Magnitude / 2
 
 		local distance = (radius / sinFov2) * dynamic.distanceScale
@@ -411,6 +412,10 @@ function AutoCaptureControllerClass._hookPointCloud(self: AutoCaptureController)
 		local tanXFov2Scaled = tanYFov2 * (viewportSize.X / viewportSize.Y) * (paddedRect.Width / viewportSize.X)
 
 		local worldPointCloud = pointCloud:getVertices()
+		if #worldPointCloud == 0 then
+			return
+		end
+
 		local cloud = { rotationInv * worldPointCloud[1] }
 		local furthest = cloud[1].Z
 		for i = 2, #worldPointCloud do

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -343,7 +343,8 @@ function AutoCaptureControllerClass._hookOrbital(self: AutoCaptureController)
 		local scaledFov2 = math.atan(math.tan(math.rad(camera.FieldOfView / 2)) * scaleY)
 		local sinFov2 = math.sin(scaledFov2 * math.min(1, aspect))
 
-		local _bboxCenter, bboxSize = AABBHelper.getPVBoundingBox(pvInstance)
+		local filteredParts = AABBHelper.getFilteredParts(pvInstance)
+		local _bboxCF, bboxSize = AABBHelper.getBoundingBox(pvInstance:GetPivot(), filteredParts)
 		local radius = bboxSize.Magnitude / 2
 
 		local distance = (radius / sinFov2) * dynamic.distanceScale

--- a/src/Main/UserInterface/Apps/AutoCapture/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/init.luau
@@ -213,7 +213,7 @@ local function appComponent(props: { ScaleOS: Vector2 })
 					focusPV.Archivable = false
 					pvInstanceCopy.Parent = focusPV
 
-					local filteredParts = AABBHelper.getFilteredParts(focusPV)
+					local filteredParts = AABBHelper.getFilteredParts(focusPV, AABBHelper.filters.ignoreTag)
 					local bboxCF, _bboxSize = AABBHelper.getBoundingBox(focusPV:GetPivot(), filteredParts)
 					local worldPivot = CFrame.new(bboxCF.Position)
 

--- a/src/Main/UserInterface/Apps/AutoCapture/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/init.luau
@@ -18,6 +18,7 @@ local Hooks = require(uiRoot.Hooks)
 local FitterWindow = require(script.Components.FitterWindow)
 local Widget = require(script.Components.Widget)
 
+local AABBHelper = require(script.Controller.AABBHelper)
 local Controller = require(script.Controller)
 
 local AutoCapture = {}
@@ -212,7 +213,7 @@ local function appComponent(props: { ScaleOS: Vector2 })
 					focusPV.Archivable = false
 					pvInstanceCopy.Parent = focusPV
 
-					local bboxCF, _bboxSize = Controller.getPVBoundingBox(focusPV)
+					local bboxCF, _bboxSize = AABBHelper.getPVBoundingBox(focusPV)
 					local worldPivot = CFrame.new(bboxCF.Position)
 
 					local pivotOffset = CFrame.identity

--- a/src/Main/UserInterface/Apps/AutoCapture/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/init.luau
@@ -213,7 +213,8 @@ local function appComponent(props: { ScaleOS: Vector2 })
 					focusPV.Archivable = false
 					pvInstanceCopy.Parent = focusPV
 
-					local bboxCF, _bboxSize = AABBHelper.getFilteredPVBoundingBox(focusPV)
+					local filteredParts = AABBHelper.getFilteredParts(focusPV, AABBHelper.ignoreTagFilter)
+					local bboxCF, _bboxSize = AABBHelper.getBoundingBox(focusPV:GetPivot(), filteredParts)
 					local worldPivot = CFrame.new(bboxCF.Position)
 
 					local pivotOffset = CFrame.identity

--- a/src/Main/UserInterface/Apps/AutoCapture/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/init.luau
@@ -213,8 +213,7 @@ local function appComponent(props: { ScaleOS: Vector2 })
 					focusPV.Archivable = false
 					pvInstanceCopy.Parent = focusPV
 
-					local filteredParts = AABBHelper.getFilteredParts(focusPV, AABBHelper.filters.ignoreTag)
-					local bboxCF, _bboxSize = AABBHelper.getBoundingBox(focusPV:GetPivot(), filteredParts)
+					local bboxCF, _bboxSize = AABBHelper.getFilteredPVBoundingBox(focusPV)
 					local worldPivot = CFrame.new(bboxCF.Position)
 
 					local pivotOffset = CFrame.identity

--- a/src/Main/UserInterface/Apps/AutoCapture/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/init.luau
@@ -213,7 +213,8 @@ local function appComponent(props: { ScaleOS: Vector2 })
 					focusPV.Archivable = false
 					pvInstanceCopy.Parent = focusPV
 
-					local bboxCF, _bboxSize = AABBHelper.getPVBoundingBox(focusPV)
+					local filteredParts = AABBHelper.getFilteredParts(focusPV)
+					local bboxCF, _bboxSize = AABBHelper.getBoundingBox(focusPV:GetPivot(), filteredParts)
 					local worldPivot = CFrame.new(bboxCF.Position)
 
 					local pivotOffset = CFrame.identity


### PR DESCRIPTION
# Problem

Currently all BaseParts inside an auto capture target are taken into account when calculating the bounds in the orbital and point cloud fit types. This can be problematic for things such as fully transparent parts as they impact how the camera should align itself to the model.

# Solution

By introducing the tag `photobooth:ignore` it now becomes very easy to filter out any instance (plus its descendants) from the fit type calculation. This allows for doing things such as ignoring all the transparent parts or having a custom bounding box.

By all means this is a power-user feature, but it is extremely helpful.