### PR TITLE
Add more free cam keycodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Unreleased
-- Fix the ability to manually set the camera CFrame when using free-cam in auto capture
+- Fix the ability to manually set the camera CFrame when using free-cam in auto capture.
+- Add the ability to use the up / down / left / right arrows on keyboard when in free-cam in auto capture.
 
 ### [2.9.0] - 2026/09/01
 - Adds support for the `photobooth:ignore` tag which can be used in auto-capture orbital and point-cloud mode to ignore instances and their descendants in bound calculations.

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -36,10 +36,16 @@ local FREE_EXTERNAL_CF_EPSILON = 1e-4
 local FREE_MOVE_KEYS = {
 	[Enum.KeyCode.D] = Vector3.xAxis,
 	[Enum.KeyCode.A] = -Vector3.xAxis,
-	[Enum.KeyCode.E] = Vector3.yAxis,
-	[Enum.KeyCode.Q] = -Vector3.yAxis,
 	[Enum.KeyCode.S] = Vector3.zAxis,
 	[Enum.KeyCode.W] = -Vector3.zAxis,
+
+	[Enum.KeyCode.E] = Vector3.yAxis,
+	[Enum.KeyCode.Q] = -Vector3.yAxis,
+
+	[Enum.KeyCode.Right] = Vector3.xAxis,
+	[Enum.KeyCode.Left] = -Vector3.xAxis,
+	[Enum.KeyCode.Up] = -Vector3.zAxis,
+	[Enum.KeyCode.Down] = Vector3.zAxis,
 }
 
 local AutoCaptureControllerStatic = {}


### PR DESCRIPTION
Adds the ability to use the up / down / left / right arrows on keyboard when in free-cam in auto capture.