### PR TITLE
Add custom auto capture origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Unreleased
 - Fix the ability to manually set the camera CFrame when using free-cam in auto capture.
 - Add the ability to use the up / down / left / right arrows on keyboard when in free-cam in auto capture.
+- Add a configurable auto capture origin so subjects can be centered at a point other than the world origin.
 
 ### [2.9.0] - 2026/09/01
 - Adds support for the `photobooth:ignore` tag which can be used in auto-capture orbital and point-cloud mode to ignore instances and their descendants in bound calculations.

--- a/src/Main/StateManager/SaveVersions/V1.luau
+++ b/src/Main/StateManager/SaveVersions/V1.luau
@@ -10,6 +10,8 @@ export type Serialized = {
 		galleryListExpanded: boolean,
 		galleryListGridView: boolean,
 		experimentalModeEnabled: boolean,
+
+		autoCaptureOrigin: Vector3,
 	},
 
 	postProcessingPresets: { any },
@@ -22,6 +24,8 @@ export type Deserialized = {
 		galleryListExpanded: boolean,
 		galleryListGridView: boolean,
 		experimentalModeEnabled: boolean,
+
+		autoCaptureOrigin: Vector3,
 	},
 
 	postProcessingPresets: { any },
@@ -37,6 +41,8 @@ function SaveFormatV1.default(): Deserialized
 			galleryListExpanded = true,
 			galleryListGridView = false,
 			experimentalModeEnabled = false,
+
+			autoCaptureOrigin = Vector3.zero,
 		},
 
 		postProcessingPresets = {},
@@ -56,7 +62,11 @@ function SaveFormatV1.serialize(deserialized: Deserialized): Serialized
 end
 
 function SaveFormatV1.deserialize(serialized: Serialized): Deserialized
-	return Sift.Dictionary.merge(SaveFormatV1.default(), serialized)
+	local default = SaveFormatV1.default()
+	return {
+		settings = Sift.Dictionary.merge(default.settings, serialized.settings),
+		postProcessingPresets = serialized.postProcessingPresets or {},
+	}
 end
 
 return SaveFormatV1

--- a/src/Main/UserInterface/Apps/AutoCapture/Components/Widget/Properties.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Components/Widget/Properties.luau
@@ -3,6 +3,7 @@ local StudioProperties = require(pluginRoot.Packages.StudioProperties)
 local React = require(pluginRoot.Packages.React)
 
 local Captures = require(pluginRoot.Main.Photo.Captures)
+local StateManager = require(pluginRoot.Main.StateManager)
 
 local AutoCaptureRoot = script:FindFirstAncestor("AutoCapture")
 local Controller = require(AutoCaptureRoot.Controller)
@@ -21,6 +22,10 @@ export type Props = {
 local function Properties(props: Props, ref: any)
 	local static = props.Controller.staticObservableState:use()
 	local dynamic = props.Controller.dynamicObservableState:use()
+
+	local origin = StateManager.settings:useSpecific()(function(state)
+		return state.autoCaptureOrigin
+	end)
 
 	return React.createElement("Frame", {
 		BackgroundTransparency = 1,
@@ -167,6 +172,21 @@ local function Properties(props: Props, ref: any)
 				FillDirection = Enum.FillDirection.Vertical,
 				SortOrder = Enum.SortOrder.LayoutOrder,
 				Padding = UDim.new(0, 0),
+			}),
+
+			Origin = React.createElement(StudioProperties.Vector3, {
+				FieldName = "Origin",
+
+				Value = origin,
+				OnValueSubmitted = function(newValue)
+					StateManager.settings:update()(function(state)
+						state.autoCaptureOrigin = newValue
+						return state
+					end)
+				end,
+
+				Disabled = props.Disabled,
+				LayoutOrder = 1,
 			}),
 
 			FOV = React.createElement(StudioProperties.Number, {

--- a/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/Controller/init.luau
@@ -123,6 +123,7 @@ export type AutoCaptureController = typeof(setmetatable(
 	{} :: {
 		captureRect: Rect,
 		isCapturing: boolean,
+		origin: Vector3,
 
 		staticObservableState: StaticObservableState,
 		dynamicObservableState: DynamicObservableState,
@@ -145,6 +146,7 @@ function AutoCaptureControllerStatic.new()
 
 	self.captureRect = Rect.new(0, 0, 0, 0)
 	self.isCapturing = false
+	self.origin = Vector3.zero
 
 	self.staticObservableState = createStaticObservableState()
 	self.dynamicObservableState = createDynamicObservableState()
@@ -355,7 +357,7 @@ function AutoCaptureControllerClass._hookOrbital(self: AutoCaptureController)
 		local radius = bboxSize.Magnitude / 2
 
 		local distance = (radius / sinFov2) * dynamic.distanceScale
-		local cameraCF = rotation * CFrame.new(0, 0, distance)
+		local cameraCF = CFrame.new(self.origin) * rotation * CFrame.new(0, 0, distance)
 
 		local distortedCF = cameraCF
 			* distort(camera, {
@@ -663,6 +665,18 @@ end
 
 function AutoCaptureControllerClass.setCaptureRect(self: AutoCaptureController, rect: Rect)
 	self.captureRect = rect
+end
+
+function AutoCaptureControllerClass.setOrigin(self: AutoCaptureController, origin: Vector3)
+	local delta = origin - self.origin
+	if delta == Vector3.zero then
+		return
+	end
+
+	self.origin = origin
+	for pvInstance, _pvState in self.stateByPV do
+		pvInstance:PivotTo(pvInstance:GetPivot() + delta)
+	end
 end
 
 function AutoCaptureControllerClass.getFocusedPVInstance(self: AutoCaptureController)

--- a/src/Main/UserInterface/Apps/AutoCapture/init.luau
+++ b/src/Main/UserInterface/Apps/AutoCapture/init.luau
@@ -88,7 +88,7 @@ local function useController()
 	return controller
 end
 
-local function appComponent(props: { ScaleOS: Vector2 })
+local function appComponent(props: { ScaleOS: Vector2, Origin: Vector3 })
 	local plugin = StudioComponents.usePlugin() :: Plugin
 	local pvsRef = React.useRef({} :: { [Widget.ListElement]: PVInstance })
 
@@ -98,6 +98,10 @@ local function appComponent(props: { ScaleOS: Vector2 })
 
 	local captureRect, setCaptureRect = React.useState(Rect.new(0, 0, 0, 0))
 	local cancelledRef = React.useRef(false)
+
+	React.useEffect(function()
+		controller:setOrigin(props.Origin)
+	end, { controller :: any, props.Origin :: any })
 
 	React.useEffect(function()
 		return function()
@@ -225,7 +229,7 @@ local function appComponent(props: { ScaleOS: Vector2 })
 
 					focusPV.Name = "AutoCaptureModel"
 					focusPV.WorldPivot = worldPivot
-					focusPV:PivotTo(pivotOffset)
+					focusPV:PivotTo(CFrame.new(controller.origin) * pivotOffset)
 
 					focusPV:SetAttribute("CaptureName", pvInstanceCopy.Name)
 
@@ -294,10 +298,15 @@ function AutoCapture.mount(plugin: Plugin, toolbar: Toolbar.Toolbar)
 		local scaleOS = StateManager.temporary:useSpecific()(function(state)
 			return state.scaleOS
 		end)
+		local autoCaptureOrigin = StateManager.settings:useSpecific()(function(state)
+			return state.autoCaptureOrigin
+		end)
 
-		return isEnabled and React.createElement(appComponent, {
-			ScaleOS = scaleOS,
-		})
+		return isEnabled
+			and React.createElement(appComponent, {
+				ScaleOS = scaleOS,
+				Origin = autoCaptureOrigin,
+			})
 	end
 
 	local dockRoot = ReactRoblox.createRoot(dock)


### PR DESCRIPTION
By default auto capture always centers around identity. This PR adds a persistent setting to allow setting that origin to something else. This is helpful for avoiding collision with your workspace.