### PR TITLE
Fix image leak in alpha bleed captures

### DIFF
--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
@@ -131,17 +131,13 @@ local function operation(options: Types.CaptureViewportOptions, isFullscreen: bo
 	end
 
 	if options.alphaBleed then
-
-		--- I dont think  we need the original image after we take a photo because Alpha bleed seems to
-		--- ^^^ return a new image for us anyway. I don't think you even use it for anything from waht I can see, its just
-		--- taking up memory. 
-		local og = capture
-		capture = errorWatch(Composers.alphaBleed(og)) 
-
+		local nonBledCapture = capture
 		trove:Add(function()
-			og:Destroy() 
+			-- we can safely mark the pre-alpha bleed image for deletion to avoid memory bloat
+			nonBledCapture:Destroy()
 		end)
 
+		capture = errorWatch(Composers.alphaBleed(nonBledCapture))
 	end
 
 	markComplete()

--- a/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
+++ b/src/Main/Photo/Captures/CaptureTypes/Viewport/NoSkybox.luau
@@ -131,7 +131,17 @@ local function operation(options: Types.CaptureViewportOptions, isFullscreen: bo
 	end
 
 	if options.alphaBleed then
-		capture = errorWatch(Composers.alphaBleed(capture))
+
+		--- I dont think  we need the original image after we take a photo because Alpha bleed seems to
+		--- ^^^ return a new image for us anyway. I don't think you even use it for anything from waht I can see, its just
+		--- taking up memory. 
+		local og = capture
+		capture = errorWatch(Composers.alphaBleed(og)) 
+
+		trove:Add(function()
+			og:Destroy() 
+		end)
+
 	end
 
 	markComplete()


### PR DESCRIPTION
# Problem
Successful captures with alpha bleed kept both the new and the original image even though only the new one was ever being used from what I could tell. Its not the greatest deal but I don't have the best hardware and on my device whenever I used the plugin it caused a mildly noticeable increase in memory. 


# Solution
Added cleanup for the original image after alpha bleed succeeds so only the final image is kept

Describe the solution you came up with
I just kept a reference to the original image before alpha bleed created a new one. then I added it to the captures cleanup so it gets destroyed whenever we finished. This just made sure that when we finished we were only left with the final image. Even if it failed for some reason the original cleanup seems to catch that scenerio. 